### PR TITLE
I couldn't start the settings with the init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,21 +138,30 @@ sudo pacman -S zsh vim curl git sqlite python python-pip
 
 **Debian and derivatives**
 ```shell
+sudo apt update
 sudo apt install zsh vim curl git sqlite3 python3 python3-pip
 ```
 
 **Fedora and derivatives**
 ```shell
+sudo dnf update
 sudo dnf install zsh vim curl git sqlite python3 python3-pip
 ```
 
-2 - Switch from **Bash** to **Zsh** and export PATH's:
+2 - Adding user's bin path to PATH:
+
+```shell
+export PATH="$PATH:$HOME/.local/bin"
+```
+
+2.1 - Switch from **Bash** to **Zsh** and export PATH's (**Optional**):
 
 ```shell
 chsh -s /bin/zsh $(whoami)
 exec zsh
 export PATH="$PATH:$HOME/.local/bin"
 ```
+> Note: By default, `ZSHPower` already performs this step at configuration time.
 
 ## Installing
 

--- a/snakypy/zshpower/cli.py
+++ b/snakypy/zshpower/cli.py
@@ -72,7 +72,7 @@ def run_credits() -> None:
     CreditsCommand().run()
 
 
-@silent_errors
+# @silent_errors
 @only_linux
 def main() -> None:
     run_init()

--- a/snakypy/zshpower/commands/init.py
+++ b/snakypy/zshpower/commands/init.py
@@ -45,6 +45,7 @@ class InitCommand(Base):
 
     def run(self, arguments, *, reload=False) -> None:
         tools_requirements("bash", "zsh", "vim", "git", "cut", "grep", "whoami", "pwd")
+        create_file(zshrc_sample, self.zsh_rc)
         if arguments["--path"]:
             stdout.write(
                 join(f'[[ -d "{self.lib_root}" ]] && source $HOME', self.source_code)

--- a/snakypy/zshpower/utils/process.py
+++ b/snakypy/zshpower/utils/process.py
@@ -30,6 +30,7 @@ def change_shell(logfile) -> bool:
     """
     if shell() != "zsh":
         try:
+            printer("[ Changing the shell from Bash to ZSH (Press Ctrl+C to cancel) ]", foreground=FG().QUESTION)
             subprocess_call(f"chsh -s $(which zsh) {whoami()}", shell=True)
             return True
         except KeyboardInterrupt:


### PR DESCRIPTION
When running the `zshpower init [--omz]` command, it would not start if it did not find the **~/.zshrc** file. A command was added to create the **~/.zshrc** file if it doesn't exist and thus correct the error.

Also removed the @silent_errors decorator to allow for error display.